### PR TITLE
Upgrade to the official BouncyCastle.Cryptography package

### DIFF
--- a/src/net-questdb-client/net-questdb-client.csproj
+++ b/src/net-questdb-client/net-questdb-client.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     </ItemGroup>
 
 </Project>

--- a/src/tcp-client-test/tcp-client-test.csproj
+++ b/src/tcp-client-test/tcp-client-test.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />


### PR DESCRIPTION
This package is maintained unlike the unofficial .net core port, which has been made redundant since bc 2.x made the issue #11 but realized there was minimal usage of BC so the upgrade was very simple.