### PR TITLE
Changed examples and added multiple framework version targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ await sender.SendAsync();
 using var sender = Sender.New("http::addr=localhost:9000;");
 for(int i = 0; i < 100; i++)
 {
-    await sender.Table("trades")
-    .Symbol("symbol", "ETH-USD")
-    .Symbol("side", "sell")
-    .Column("price", 2615.54)
-    .Column("amount", 0.00044)
-    .AtNowAsync();
+    sender.Table("trades")
+      .Symbol("symbol", "ETH-USD")
+      .Symbol("side", "sell")
+      .Column("price", 2615.54)
+      .Column("amount", 0.00044)
+      .At(DateTime.UtcNow);
 }
-await sender.SendAsync();
+sender.Send();
 ```
 
 ### Auto-Flush

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ See more in-depth documentation [here](https://questdb.io/docs/clients/ingest-do
 ### Basic usage
 
 ```csharp
-using var sender = Sender.New("http::addr=localhost:9000;");
-await sender.Table("metric_name")
-    .Symbol("Symbol", "value")
-    .Column("number", 10)
-    .Column("double", 12.23)
-    .Column("string", "born to shine")
+using var sender =  Sender.New("http::addr=localhost:9000;");
+await sender.Table("trades")
+    .Symbol("symbol", "ETH-USD")
+    .Symbol("side", "sell")
+    .Column("price", 2615.54)
+    .Column("amount", 0.00044)
     .AtAsync(new DateTime(2021, 11, 25, 0, 46, 26));
 await sender.SendAsync();
 ```
@@ -53,14 +53,17 @@ await sender.SendAsync();
 ### Multi-line send (sync)
 
 ```csharp
-using var sender = Sender.New("http::addr=localhost:9000;auto_flush=off;");
+using var sender = Sender.New("http::addr=localhost:9000;");
 for(int i = 0; i < 100; i++)
 {
-    sender.Table("metric_name")
-        .Column("counter", i)
-        .AtNow();
+    await sender.Table("trades")
+    .Symbol("symbol", "ETH-USD")
+    .Symbol("side", "sell")
+    .Column("price", 2615.54)
+    .Column("amount", 0.00044)
+    .AtNowAsync();
 }
-sender.Send();
+await sender.SendAsync();
 ```
 
 ### Auto-Flush
@@ -107,13 +110,13 @@ using var sender = Sender.New("http::addr=localhost:9000;auto_flush=on;auto_flus
 #### HTTP Authentication (Basic)
 
 ```csharp
-using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;username=admin;password=quest;");;
+using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;username=admin;password=quest;");
 ```
 
 #### HTTP Authentication (Token)
 
 ```csharp
-using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;username=admin;token=<bearer token>");;
+using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;username=admin;token=<bearer token>");
 ```
 
 #### TCP Authentication

--- a/src/example-auth-http-tls/Program.cs
+++ b/src/example-auth-http-tls/Program.cs
@@ -13,13 +13,13 @@ await sender.Table("trades")
     .Symbol("side", "sell")
     .Column("price", 2615.54)
     .Column("amount", 0.00044)
-    .AtNowAsync();
+    .AtAsync(DateTime.UtcNow);
 
 await sender.Table("trades")
     .Symbol("symbol", "BTC-USD")
     .Symbol("side", "sell")
     .Column("price", 39269.98)
     .Column("amount", 0.001)
-    .AtNowAsync();
+    .AtAsync(DateTime.UtcNow);
 
 await sender.SendAsync();

--- a/src/example-auth-http-tls/Program.cs
+++ b/src/example-auth-http-tls/Program.cs
@@ -2,21 +2,24 @@
 
 
 // Runs against QuestDB Enterprise, demonstrating HTTPS and Basic Authentication support.
+// Disabling tls verification. Note this is not a best practice in production
 
 using var sender =
     Sender.New("https::addr=localhost:9000;tls_verify=unsafe_off;username=admin;password=quest;");
-await sender.Table("trades_dotnet")
-    .Symbol("pair", "USDGBP")
-    .Symbol("type", "buy")
-    .Column("traded_price", 0.83)
-    .Column("limit_price", 0.84)
-    .Column("qty", 100)
-    .Column("traded_ts", new DateTime(
-        2022, 8, 6, 7, 35, 23, 189, DateTimeKind.Utc))
-    .AtAsync(DateTime.UtcNow);
-await sender.Table("trades_dotnet")
-    .Symbol("pair", "GBPJPY")
-    .Column("traded_price", 135.97)
-    .Column("qty", 400)
-    .AtAsync(DateTime.UtcNow);
+    // See: https://questdb.io/docs/operations/rbac/#authentication
+
+await sender.Table("trades")
+    .Symbol("symbol", "ETH-USD")
+    .Symbol("side", "sell")
+    .Column("price", 2615.54)
+    .Column("amount", 0.00044)
+    .AtNowAsync();
+
+await sender.Table("trades")
+    .Symbol("symbol", "BTC-USD")
+    .Symbol("side", "sell")
+    .Column("price", 39269.98)
+    .Column("amount", 0.001)
+    .AtNowAsync();
+
 await sender.SendAsync();

--- a/src/example-auth-http-tls/example-auth-http-tls.csproj
+++ b/src/example-auth-http-tls/example-auth-http-tls.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <RootNamespace>example_auth_http_tls</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/example-auth-tls/Program.cs
+++ b/src/example-auth-tls/Program.cs
@@ -15,14 +15,14 @@ await sender.Table("trades")
     .Symbol("side", "sell")
     .Column("price", 2615.54)
     .Column("amount", 0.00044)
-    .AtNowAsync();
+    .AtAsync(DateTime.UtcNow);
 
 await sender.Table("trades")
     .Symbol("symbol", "BTC-USD")
     .Symbol("side", "sell")
     .Column("price", 39269.98)
     .Column("amount", 0.001)
-    .AtNowAsync();
+    .AtAsync(DateTime.UtcNow);
 
 await sender.SendAsync();
 

--- a/src/example-auth-tls/Program.cs
+++ b/src/example-auth-tls/Program.cs
@@ -3,24 +3,26 @@ using QuestDB;
 
 
 //    Demonstrates TCPS connection against QuestDB Enterprise
+//    Disabling tls verification. Note this is not a best practice in production
 
 using var sender =
     Sender.New(
         "tcps::addr=localhost:9009;tls_verify=unsafe_off;username=admin;token=NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=;");
-// See: https://questdb.io/docs/reference/api/ilp/authenticate
-await sender.Table("trades_dotnet")
-    .Symbol("pair", "USDGBP")
-    .Symbol("type", "buy")
-    .Column("traded_price", 0.83)
-    .Column("limit_price", 0.84)
-    .Column("qty", 100)
-    .Column("traded_ts", new DateTime(
-        2022, 8, 6, 7, 35, 23, 189, DateTimeKind.Utc))
-    .AtAsync(DateTime.UtcNow);
-await sender.Table("trades_dotnet")
-    .Symbol("pair", "GBPJPY")
-    .Column("traded_price", 135.97)
-    .Column("qty", 400)
-    .AtAsync(DateTime.UtcNow);
+    // See: https://questdb.io/docs/operations/rbac/#authentication
+
+await sender.Table("trades")
+    .Symbol("symbol", "ETH-USD")
+    .Symbol("side", "sell")
+    .Column("price", 2615.54)
+    .Column("amount", 0.00044)
+    .AtNowAsync();
+
+await sender.Table("trades")
+    .Symbol("symbol", "BTC-USD")
+    .Symbol("side", "sell")
+    .Column("price", 39269.98)
+    .Column("amount", 0.001)
+    .AtNowAsync();
+
 await sender.SendAsync();
 

--- a/src/example-auth-tls/example-auth-tls.csproj
+++ b/src/example-auth-tls/example-auth-tls.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Title>QuestDB client - Example with Authentication and TLS</Title>
         <Description>Authentication and TLS example using the QuestDB ILP protocol client</Description>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 

--- a/src/example-basic/Program.cs
+++ b/src/example-basic/Program.cs
@@ -7,13 +7,13 @@ await sender.Table("trades")
     .Symbol("side", "sell")
     .Column("price", 2615.54)
     .Column("amount", 0.00044)
-    .AtNowAsync();
+    .AtAsync(DateTime.UtcNow);
 
 await sender.Table("trades")
     .Symbol("symbol", "BTC-USD")
     .Symbol("side", "sell")
     .Column("price", 39269.98)
     .Column("amount", 0.001)
-    .AtNowAsync();
+    .AtAsync(DateTime.UtcNow);
 
 await sender.SendAsync();

--- a/src/example-basic/Program.cs
+++ b/src/example-basic/Program.cs
@@ -2,18 +2,18 @@
 using QuestDB;
 
 using var sender =  Sender.New("http::addr=localhost:9000;");
-await sender.Table("trades_dotnet")
-    .Symbol("pair", "USDGBP")
-    .Symbol("type", "buy")
-    .Column("traded_price", 0.83)
-    .Column("limit_price", 0.84)
-    .Column("qty", 100)
-    .Column("traded_ts", new DateTime(
-        2022, 8, 6, 7, 35, 23, 189, DateTimeKind.Utc))
-    .AtAsync(DateTime.UtcNow);
-await sender.Table("trades_dotnet")
-    .Symbol("pair", "GBPJPY")
-    .Column("traded_price", 135.97)
-    .Column("qty", 400)
-    .AtAsync(DateTime.UtcNow);
+await sender.Table("trades")
+    .Symbol("symbol", "ETH-USD")
+    .Symbol("side", "sell")
+    .Column("price", 2615.54)
+    .Column("amount", 0.00044)
+    .AtNowAsync();
+
+await sender.Table("trades")
+    .Symbol("symbol", "BTC-USD")
+    .Symbol("side", "sell")
+    .Column("price", 39269.98)
+    .Column("amount", 0.001)
+    .AtNowAsync();
+
 await sender.SendAsync();

--- a/src/example-basic/example-basic.csproj
+++ b/src/example-basic/example-basic.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Title>QuestDB client - Basic Example</Title>
         <Description>Basic example using the QuestDB ILP protocol client</Description>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 

--- a/src/example-streaming/Program.cs
+++ b/src/example-streaming/Program.cs
@@ -10,15 +10,12 @@ timer.Start();
 
 for (var i = 0; i < rowsToSend; i++)
 {
-    await sender.Table("trades_dotnet")
-        .Symbol("pair", "USDGBP")
-        .Symbol("type", "buy")
-        .Column("traded_price", 0.83)
-        .Column("limit_price", 0.84)
-        .Column("qty", 100)
-        .Column("traded_ts", new DateTime(
-            2022, 8, 6, 7, 35, 23, 189, DateTimeKind.Utc))
-        .AtAsync(DateTime.UtcNow);
+    await sender.Table("trades")
+        .Symbol("symbol", "ETH-USD")
+        .Symbol("side", "sell")
+        .Column("price", 2615.54)
+        .Column("amount", 0.00044)
+        .AtNowAsync();
 }
 
 // Ensure no pending rows.

--- a/src/example-streaming/Program.cs
+++ b/src/example-streaming/Program.cs
@@ -15,7 +15,7 @@ for (var i = 0; i < rowsToSend; i++)
         .Symbol("side", "sell")
         .Column("price", 2615.54)
         .Column("amount", 0.00044)
-        .AtNowAsync();
+        .AtAsync(DateTime.UtcNow);
 }
 
 // Ensure no pending rows.

--- a/src/example-streaming/example-streaming.csproj
+++ b/src/example-streaming/example-streaming.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <RootNamespace>example_streaming</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/net-questdb-client-tests/net-questdb-client-tests.csproj
+++ b/src/net-questdb-client-tests/net-questdb-client-tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <RootNamespace>net_questdb_client_tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/tcp-client-test/tcp-client-test.csproj
+++ b/src/tcp-client-test/tcp-client-test.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>tcp_client_test</RootNamespace>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 


### PR DESCRIPTION
Examples now use the trades dataset and are consistent with main docs and rest of clients.

Made all the examples plus the tests target multiple versions, so net6.0, net7.0 and net8.0 can be used