### PR TITLE
fix: upgrade BouncyCastle.Cryptography to v2.5.0 to resolve security vulnerability

### DIFF
--- a/src/net-questdb-client/net-questdb-client.csproj
+++ b/src/net-questdb-client/net-questdb-client.csproj
@@ -20,6 +20,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1"/>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
     </ItemGroup>
 </Project>

--- a/src/tcp-client-test/tcp-client-test.csproj
+++ b/src/tcp-client-test/tcp-client-test.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1"/>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
         <PackageReference Include="NUnit" Version="3.13.2"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0"/>


### PR DESCRIPTION
The BouncyCastle.Cryptography version `2.2.1` has 3 security vulnerabilities. One of these vulnerabilities has a severity of `6.9 / 10`. The vulnerabilities are listed here: https://www.nuget.org/packages/BouncyCastle.Cryptography/2.2.1.

The pull request is related to https://github.com/questdb/net-questdb-client/issues/30. The previous pull request has been open for  **2 months**, it would be great if one of them could be resolved.