### PR TITLE
chore: BREAKING 💥 refactor dependencies and update BouncyCastle.Cryptography to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 Use NuGet to add a dependency on this library.
 
 See: [https://www.nuget.org/packages/net-questdb-client/](https://www.nuget.org/packages/net-questdb-client/)
+(Optional) to use the client with TCP protocol authentication add Neget refrence to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/)
 
 ## Usage
 
@@ -121,6 +122,8 @@ using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;
 
 #### TCP Authentication
 
+💥 starting from version 2.1 to use TCP Authentication add reference to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/)
+
 ```csharp
 using var sender = Sender.New("tcps::addr=localhost:9009;tls_verify=unsafe_off;username=admin;token=NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=;");
 ```
@@ -147,7 +150,7 @@ The config string format is:
 | `max_buf_size`           | `104857600`                | Maximum size of the byte buffer in bytes. If exceeded, an exception will be thrown.                                                                             |
 | `username`               |                            | The username for authentication. Used for Basic Authentication and TCP JWK Authentication.                                                                      |
 | `password`               |                            | The password for authentication. Used for Basic Authentication.                                                                                                 |
-| `token`                  |                            | The token for authentication. Used for Token Authentication and TCP JWK Authentication.                                                                         |
+| `token`                  |                            | The token for authentication. Used for Token Authentication and TCP JWK Authentication, needs additional reference to `net-questdb-client-tcp-auth` assembly    |
 | `token_x`                |                            | Un-used.                                                                                                                                                        |
 | `token_y`                |                            | Un-used.                                                                                                                                                        |
 | `tls_verify`             | `on`                       | Denotes whether TLS certificates should or should not be verifed. Options are on/unsafe_off.                                                                    |
@@ -202,6 +205,11 @@ The config string format is:
 
 No. This client is for writing data only. For querying, see
 the [Query & SQL overview](https://questdb.io/docs/reference/sql/overview/)
+
+### I updated from version < 2.0.0 and now have error `Could not load QuestDB.Secp256r1SignatureGenerator, please add a reference to assembly "net-client-questdb-tcp-auth\"`
+
+Since version 2.1.0 in order to use TCP authenticaion an additional nuget package is needed [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
+This is done to remove the dependency on `BouncyCastle.Cryptography` and only add it when it is really needed.
 
 ### Where do I report issues with the client?
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 Use NuGet to add a dependency on this library.
 
 See: [https://www.nuget.org/packages/net-questdb-client/](https://www.nuget.org/packages/net-questdb-client/)
-(Optional) to use the client with TCP protocol authentication add Neget refrence to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/)
+(Optional) to use the client with TCP protocol authentication add NuGet refrence to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/)
 
 ## Usage
 
@@ -122,7 +122,7 @@ using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;
 
 #### TCP Authentication
 
-💥 starting from version 2.1 to use TCP Authentication add reference to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/)
+💥 From net-questdb-client Version 2.1.0, if you want to use TCP Authentication , you must add a reference to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
 
 ```csharp
 using var sender = Sender.New("tcps::addr=localhost:9009;tls_verify=unsafe_off;username=admin;token=NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=;");
@@ -208,8 +208,8 @@ the [Query & SQL overview](https://questdb.io/docs/reference/sql/overview/)
 
 ### I updated from version < 2.0.0 and now have error `Could not load QuestDB.Secp256r1SignatureGenerator, please add a reference to assembly "net-client-questdb-tcp-auth\"`
 
-Since version 2.1.0 in order to use TCP authenticaion an additional nuget package is needed [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
-This is done to remove the dependency on `BouncyCastle.Cryptography` and only add it when it is really needed.
+Since Version 2.1.0, in order to use TCP authentication an additional NuGet package is required [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
+This is changed to remove the dependency on `BouncyCastle.Cryptography` from the main library, since it was only required for TCP authentication.
 
 ### Where do I report issues with the client?
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ the [Query & SQL overview](https://questdb.io/docs/reference/sql/overview/)
 
 ### I updated from version < 2.0.0 and now have error `Could not load QuestDB.Secp256r1SignatureGenerator, please add a reference to assembly "net-client-questdb-tcp-auth\"`
 
-Since Version 2.1.0, in order to use TCP authentication an additional NuGet package is required [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
-This is changed to remove the dependency on `BouncyCastle.Cryptography` from the main library, since it was only required for TCP authentication.
+Since Version 2.1.0, in order to use TCP authentication, an additional NuGet package is required [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
+This was changed to remove the dependency on `BouncyCastle.Cryptography` from the main library, since it was only required for TCP authentication.
 
 ### Where do I report issues with the client?
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ using var sender = Sender.New("https::addr=localhost:9009;tls_verify=unsafe_off;
 
 #### TCP Authentication
 
-💥 From net-questdb-client Version 2.1.0, if you want to use TCP Authentication , you must add a reference to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
+💥 From net-questdb-client Version 2.1.0, if you want to use TCP Authentication, you must add a reference to [https://www.nuget.org/packages/net-questdb-client-tcp-auth/](https://www.nuget.org/packages/net-questdb-client-tcp-auth/).
 
 ```csharp
 using var sender = Sender.New("tcps::addr=localhost:9009;tls_verify=unsafe_off;username=admin;token=NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=;");

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "9.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/net-questdb-client.sln
+++ b/net-questdb-client.sln
@@ -23,7 +23,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-auth-http-tls", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net-client-questdb-tcp-auth", "src\net-client-questdb-tcp-auth\net-client-questdb-tcp-auth.csproj", "{EF86C5A3-71BE-4D9C-9647-B1A50751F244}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net-questdb-client-tests", "src\net-questdb-client-tcp-auth-tests\net-questdb-client-tcp-auth-tests.csproj", "{628A6AE1-C0D4-4A40-98DF-1F094BD60203}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net-questdb-client-tcp-auth-test", "src\net-questdb-client-tcp-auth-tests\net-questdb-client-tcp-auth-tests.csproj", "{628A6AE1-C0D4-4A40-98DF-1F094BD60203}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/net-questdb-client.sln
+++ b/net-questdb-client.sln
@@ -21,6 +21,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-streaming", "src\ex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-auth-http-tls", "src\example-auth-http-tls\example-auth-http-tls.csproj", "{24D93DBB-3783-423F-81CC-6B9BFD33F6CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net-client-questdb-tcp-auth", "src\net-client-questdb-tcp-auth\net-client-questdb-tcp-auth.csproj", "{EF86C5A3-71BE-4D9C-9647-B1A50751F244}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net-questdb-client-tests", "src\net-questdb-client-tcp-auth-tests\net-questdb-client-tcp-auth-tests.csproj", "{628A6AE1-C0D4-4A40-98DF-1F094BD60203}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,5 +70,13 @@ Global
 		{24D93DBB-3783-423F-81CC-6B9BFD33F6CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24D93DBB-3783-423F-81CC-6B9BFD33F6CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{24D93DBB-3783-423F-81CC-6B9BFD33F6CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF86C5A3-71BE-4D9C-9647-B1A50751F244}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF86C5A3-71BE-4D9C-9647-B1A50751F244}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF86C5A3-71BE-4D9C-9647-B1A50751F244}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF86C5A3-71BE-4D9C-9647-B1A50751F244}.Release|Any CPU.Build.0 = Release|Any CPU
+		{628A6AE1-C0D4-4A40-98DF-1F094BD60203}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{628A6AE1-C0D4-4A40-98DF-1F094BD60203}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{628A6AE1-C0D4-4A40-98DF-1F094BD60203}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{628A6AE1-C0D4-4A40-98DF-1F094BD60203}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/dummy-http-server/dummy-http-server.csproj
+++ b/src/dummy-http-server/dummy-http-server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>dummy_http_server</RootNamespace>

--- a/src/example-auth-http-tls/example-auth-http-tls.csproj
+++ b/src/example-auth-http-tls/example-auth-http-tls.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <RootNamespace>example_auth_http_tls</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/example-auth-tls/example-auth-tls.csproj
+++ b/src/example-auth-tls/example-auth-tls.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Title>QuestDB client - Example with Authentication and TLS</Title>
         <Description>Authentication and TLS example using the QuestDB ILP protocol client</Description>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 

--- a/src/example-basic/example-basic.csproj
+++ b/src/example-basic/example-basic.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Title>QuestDB client - Basic Example</Title>
         <Description>Basic example using the QuestDB ILP protocol client</Description>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 

--- a/src/example-streaming/example-streaming.csproj
+++ b/src/example-streaming/example-streaming.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <RootNamespace>example_streaming</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/net-client-questdb-tcp-auth/Secp256r1SignatureGenerator.cs
+++ b/src/net-client-questdb-tcp-auth/Secp256r1SignatureGenerator.cs
@@ -1,0 +1,25 @@
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+
+namespace QuestDB;
+
+public class Secp256r1SignatureGenerator : ISignatureGenerator
+{
+    public byte[] GenerateSignature(byte[] privateKey, byte[] buffer, int bufferLen)
+    {
+        var p = SecNamedCurves.GetByName("secp256r1");
+        var parameters = new ECDomainParameters(p.Curve, p.G, p.N, p.H);
+        var priKey = new ECPrivateKeyParameters(
+            "ECDSA",
+            new BigInteger(1, privateKey), // d
+            parameters);
+
+        var ecdsa = SignerUtilities.GetSigner("SHA-256withECDSA");
+        ecdsa.Init(true, priKey);
+        ecdsa.BlockUpdate(buffer, 0, bufferLen);
+        var signature = ecdsa.GenerateSignature();
+        return signature;
+    }
+}

--- a/src/net-client-questdb-tcp-auth/net-client-questdb-tcp-auth.csproj
+++ b/src/net-client-questdb-tcp-auth/net-client-questdb-tcp-auth.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <RootNamespace>net_client_questdb_tcp</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\net-questdb-client\net-questdb-client.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0"/>
+    </ItemGroup>
+</Project>

--- a/src/net-questdb-client-benchmarks/net-questdb-client-benchmarks.csproj
+++ b/src/net-questdb-client-benchmarks/net-questdb-client-benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
         <RootNamespace>net_questdb_client_benchmarks</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/net-questdb-client-tcp-auth-tests/TcpTests.cs
+++ b/src/net-questdb-client-tcp-auth-tests/TcpTests.cs
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+
+using System.Net;
+using System.Text;
+using NUnit.Framework;
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using QuestDB;
+using QuestDB.Utils;
+
+namespace net_questdb_client_tests;
+
+public class TcpTests
+{
+    private readonly IPAddress _host = IPAddress.Loopback;
+    private readonly int _port = 29472;
+
+    [Test]
+    public async Task Authenticate()
+    {
+        using var srv = CreateTcpListener(_port);
+        srv.WithAuth("testUser1", "Vs4e-cOLsVCntsMrZiAGAZtrkPXO00uoRLuA3d7gEcI=",
+            "ANhR2AZSs4ar9urE5AZrJqu469X0r7gZ1BBEdcrAuL_6");
+        srv.AcceptAsync();
+
+        using var sender =
+            Sender.New(
+                $"tcp::addr={_host}:{_port};username=testUser1;token=NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=;");
+
+        await sender.Table("metric name")
+            .Symbol("t a g", "v alu, e")
+            .Column("number", 10)
+            .Column("string", " -=\"")
+            .AtAsync(new DateTime(1970, 01, 01, 0, 0, 1));
+        await sender.SendAsync();
+
+        var expected = "metric\\ name,t\\ a\\ g=v\\ alu\\,\\ e number=10i,string=\" -=\\\"\" 1000000000\n";
+        WaitAssert(srv, expected);
+    }
+
+    [Test]
+    public async Task AuthFailWrongKid()
+    {
+        using var srv = CreateTcpListener(_port);
+        srv.WithAuth("testUser1", "Vs4e-cOLsVCntsMrZiAGAZtrkPXO00uoRLuA3d7gEcI=",
+            "ANhR2AZSs4ar9urE5AZrJqu469X0r7gZ1BBEdcrAuL_6");
+        srv.AcceptAsync();
+
+        Assert.That(
+            () => Sender.New($"tcp::addr={_host}:{_port};username=invalid;token=foo=;")
+            ,
+            Throws.TypeOf<AggregateException>().With.InnerException.TypeOf<IngressError>().With.Message
+                .Contains("Authentication failed")
+        );
+    }
+
+    [Test]
+    public async Task AuthFailBadKey()
+    {
+        using var srv = CreateTcpListener(_port);
+        srv.WithAuth("testUser1", "Vs4e-cOLsVCntsMrZiAGAZtrkPXO00uoRLuA3d7gEcI=",
+            "ANhR2AZSs4ar9urE5AZrJqu469X0r7gZ1BBEdcrAuL_6");
+        srv.AcceptAsync();
+        
+        using var sender = Sender.New(
+            $"tcp::addr={_host}:{_port};username=testUser1;token=ZOvHHNQBGvZuiCLt7CmWt0tTlsnjm9F3O3C749wGT_M=;");
+
+        Assert.That(
+            async () =>
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    await sender.Table("metric name")
+                        .Symbol("t a g", "v alu, e")
+                        .Column("number", 10)
+                        .Column("string", " -=\"")
+                        .AtAsync(new DateTime(1970, 01, 01, 0, 0, 1));
+                    await sender.SendAsync();
+                    Thread.Sleep(10);
+                }
+
+                Assert.Fail();
+            },
+            Throws.TypeOf<IngressError>().With.Message
+                .Contains("Could not write data to server.")
+        );
+    }
+
+    [Test]
+    public void EcdsaSignatureLoop()
+    {
+        var privateKey = Convert.FromBase64String("NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=");
+        var p = SecNamedCurves.GetByName("secp256r1");
+        var parameters = new ECDomainParameters(p.Curve, p.G, p.N, p.H);
+        var priKey = new ECPrivateKeyParameters(
+            "ECDSA",
+            new BigInteger(privateKey), // d
+            parameters);
+
+        var m = new byte[512];
+        for (var i = 0; i < m.Length; i++)
+        {
+            m[i] = (byte)i;
+        }
+
+        var ecdsa = SignerUtilities.GetSigner("SHA-256withECDSA");
+        ecdsa.Init(true, priKey);
+        ecdsa.BlockUpdate(m, 0, m.Length);
+        var signature = ecdsa.GenerateSignature();
+
+        var pubKey1 = FromBase64String("Vs4e-cOLsVCntsMrZiAGAZtrkPXO00uoRLuA3d7gEcI=");
+        var pubKey2 = FromBase64String("ANhR2AZSs4ar9urE5AZrJqu469X0r7gZ1BBEdcrAuL_6");
+
+        // Verify the signature
+        var pubKey = new ECPublicKeyParameters(
+            parameters.Curve.CreatePoint(new BigInteger(pubKey1), new BigInteger(pubKey2)),
+            parameters);
+
+        ecdsa.Init(false, pubKey);
+        ecdsa.BlockUpdate(m, 0, m.Length);
+        Assert.That(ecdsa.VerifySignature(signature));
+    }
+    
+    private static void WaitAssert(DummyIlpServer srv, string expected)
+    {
+        var expectedLen = Encoding.UTF8.GetBytes(expected).Length;
+        for (var i = 0; i < 500 && srv.TotalReceived < expectedLen; i++)
+        {
+            Thread.Sleep(10);
+        }
+
+        Assert.That(srv.GetTextReceived(), Is.EqualTo(expected));
+    }
+
+    private DummyIlpServer CreateTcpListener(int port, bool tls = false)
+    {
+        return new DummyIlpServer(port, tls);
+    }
+
+    private byte[] FromBase64String(string text)
+    {
+        return DummyIlpServer.FromBase64String(text);
+    }
+}

--- a/src/net-questdb-client-tcp-auth-tests/net-questdb-client-tcp-auth-tests.csproj
+++ b/src/net-questdb-client-tcp-auth-tests/net-questdb-client-tcp-auth-tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <RootNamespace>net_questdb_client_tcp_auth_tests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <AssemblyName>net-questdb-client-tcp-auth-tests</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageReference Include="NUnit" Version="3.13.3"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.1.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\dummy-http-server\dummy-http-server.csproj"/>
+        <ProjectReference Include="..\net-client-questdb-tcp-auth\net-client-questdb-tcp-auth.csproj" />
+        <ProjectReference Include="..\net-questdb-client-tests\net-questdb-client-tests.csproj" />
+        <ProjectReference Include="..\net-questdb-client\net-questdb-client.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="certificate.pfx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="config.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/src/net-questdb-client-tests/net-questdb-client-tests.csproj
+++ b/src/net-questdb-client-tests/net-questdb-client-tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <RootNamespace>net_questdb_client_tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -21,6 +21,7 @@
     <ItemGroup>
         <ProjectReference Include="..\dummy-http-server\dummy-http-server.csproj"/>
         <ProjectReference Include="..\net-questdb-client\net-questdb-client.csproj"/>
+
     </ItemGroup>
 
     <ItemGroup>
@@ -35,5 +36,8 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
     </ItemGroup>
-
+    
+    <ItemGroup>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0"/>
+    </ItemGroup>
 </Project>

--- a/src/net-questdb-client/ISignatureGenerator.cs
+++ b/src/net-questdb-client/ISignatureGenerator.cs
@@ -1,0 +1,6 @@
+namespace QuestDB;
+
+public interface ISignatureGenerator
+{
+    byte[] GenerateSignature(byte[] privateKey, byte[] buffer, int bufferLen);
+}

--- a/src/net-questdb-client/LineTcpSender.cs
+++ b/src/net-questdb-client/LineTcpSender.cs
@@ -227,8 +227,6 @@ public class LineTcpSender : IDisposable
         _position = 0;
     }
 
-
-
     /// <summary>
     ///     Set table name for the Line. Table name can be different from line to line.
     /// </summary>

--- a/src/net-questdb-client/LineTcpSender.cs
+++ b/src/net-questdb-client/LineTcpSender.cs
@@ -28,11 +28,6 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Org.BouncyCastle.Asn1.Sec;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Math;
-using Org.BouncyCastle.Security;
-
 // ReSharper disable InconsistentNaming
 
 namespace QuestDB;
@@ -45,7 +40,7 @@ public class LineTcpSender : IDisposable
 {
     private static readonly RemoteCertificateValidationCallback AllowAllCertCallback = (_, _, _, _) => true;
     private static readonly long EpochTicks = new DateTime(1970, 1, 1).Ticks;
-    public static int DefaultQuestDbFsFileNameLimit = 127;
+    public static readonly int DefaultQuestDbFsFileNameLimit = 127;
     private readonly BufferOverflowHandling _bufferOverflowHandling;
     private readonly List<(byte[] Buffer, int Length)> _buffers = new();
     private readonly Stream _networkStream;
@@ -60,6 +55,7 @@ public class LineTcpSender : IDisposable
     private bool _quoted;
     private byte[] _sendBuffer;
     private Socket? _underlyingSocket;
+    public ISignatureGenerator? _signatureGenerator;
 
     private LineTcpSender(Stream networkStream, int bufferSize,
         BufferOverflowHandling bufferOverflowHandling)
@@ -219,25 +215,19 @@ public class LineTcpSender : IDisposable
         var bufferLen = await ReceiveUntil('\n', cancellationToken);
 
         var privateKey = FromBase64String(encodedPrivateKey);
-
-        var p = SecNamedCurves.GetByName("secp256r1");
-        var parameters = new ECDomainParameters(p.Curve, p.G, p.N, p.H);
-        var priKey = new ECPrivateKeyParameters(
-            "ECDSA",
-            new BigInteger(1, privateKey), // d
-            parameters);
-
-        var ecdsa = SignerUtilities.GetSigner("SHA-256withECDSA");
-        ecdsa.Init(true, priKey);
-        ecdsa.BlockUpdate(_sendBuffer, 0, bufferLen);
-        var signature = ecdsa.GenerateSignature();
-
+        if (_signatureGenerator == null)
+        {
+            _signatureGenerator = Signatures.CreateSignatureGenerator();
+        }
+        var signature = _signatureGenerator.GenerateSignature(privateKey, _sendBuffer, bufferLen);
         Base64.EncodeToUtf8(signature, _sendBuffer, out _, out _position);
         _sendBuffer[_position++] = (byte)'\n';
 
         await _networkStream.WriteAsync(_sendBuffer, 0, _position, cancellationToken);
         _position = 0;
     }
+
+
 
     /// <summary>
     ///     Set table name for the Line. Table name can be different from line to line.

--- a/src/net-questdb-client/Signatures.cs
+++ b/src/net-questdb-client/Signatures.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+
+namespace QuestDB;
+
+public static class Signatures
+{
+    private static readonly Type? SignGenType = LoadSignatureGeneratorType();
+
+    public static ISignatureGenerator CreateSignatureGenerator()
+    {
+        ISignatureGenerator? val = null;
+        if (SignGenType != null)
+        {
+            val = (ISignatureGenerator?)Activator.CreateInstance(SignGenType);
+        }
+
+        if (val == null)
+        {
+            throw new TypeLoadException(
+                "Could not load QuestDB.Secp256r1SignatureGenerator, please add a reference to assembly \"net-client-questdb-tcp-auth\": ");
+        }
+        return val;
+    }
+
+    private static Type? LoadSignatureGeneratorType()
+    {
+        Exception? ex = null;
+        try
+        {
+            var assembly = Assembly.LoadFrom("net-client-questdb-tcp-auth.dll");
+            Type? type = assembly.GetType("QuestDB.Secp256r1SignatureGenerator");
+            if (type != null)
+            {
+                return type;
+            }
+        }
+        catch (Exception e)
+        {
+            ex = e;
+        }
+
+        Console.Error.WriteLine(
+            "Could not load QuestDB.Secp256r1SignatureGenerator, please add a reference to assembly \"net-client-questdb-tcp-auth\": " +
+            (ex == null  ? "cannot load the type, return value is null"  : ex.ToString()));
+        return null;
+    }
+}

--- a/src/net-questdb-client/net-questdb-client.csproj
+++ b/src/net-questdb-client/net-questdb-client.csproj
@@ -15,11 +15,7 @@
         <PackageTags>QuestDB, ILP</PackageTags>
         <Company>QuestDB Limited</Company>
         <PackageVersion>2.0.0</PackageVersion>
-        <TargetFramework>net6.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1"/>
-    </ItemGroup>
 </Project>

--- a/src/tcp-client-test/LineTcpSenderTests.cs
+++ b/src/tcp-client-test/LineTcpSenderTests.cs
@@ -106,38 +106,6 @@ public class LineTcpSenderTests
     }
 
     [Test]
-    public async Task AuthFailBadKey()
-    {
-        using var srv = CreateTcpListener(_port);
-        srv.WithAuth("testUser1", "Vs4e-cOLsVCntsMrZiAGAZtrkPXO00uoRLuA3d7gEcI=",
-            "ANhR2AZSs4ar9urE5AZrJqu469X0r7gZ1BBEdcrAuL_6");
-        srv.AcceptAsync();
-
-        using var ls = await LineTcpSender.ConnectAsync(IPAddress.Loopback.ToString(), _port, tlsMode: TlsMode.Disable);
-        try
-        {
-            await ls.AuthenticateAsync("testUser1", "ZOvHHNQBGvZuiCLt7CmWt0tTlsnjm9F3O3C749wGT_M=");
-            for (var i = 0; i < 10; i++)
-            {
-                ls.Table("metric name")
-                    .Symbol("t a g", "v alu, e")
-                    .Column("number", 10)
-                    .Column("string", " -=\"")
-                    .At(new DateTime(1970, 01, 01, 0, 0, 1));
-                ls.Send();
-                Thread.Sleep(10);
-            }
-
-            Assert.Fail();
-        }
-        catch (IOException ex)
-        {
-            StringAssert.StartsWith("Unable to write data to the transport connection: ", ex.Message,
-                "Bad exception message");
-        }
-    }
-
-    [Test]
     public void EcdsaSingnatureLoop()
     {
         var privateKey = Convert.FromBase64String("NgdiOWDoQNUP18WOnb1xkkEG5TzPYMda5SiUOvT1K0U=");

--- a/src/tcp-client-test/tcp-client-test.csproj
+++ b/src/tcp-client-test/tcp-client-test.csproj
@@ -4,12 +4,12 @@
         <RootNamespace>tcp_client_test</RootNamespace>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1"/>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
         <PackageReference Include="NUnit" Version="3.13.2"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0"/>
@@ -17,6 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\net-client-questdb-tcp-auth\net-client-questdb-tcp-auth.csproj" />
         <ProjectReference Include="..\net-questdb-client\net-questdb-client.csproj"/>
     </ItemGroup>
 


### PR DESCRIPTION
Dependency to `BouncyCastle.Cryptography` assembly is now removed from the main `net-client-questdb` assembly.
To use ILP TCP with authentication an additional reference to the new `net-client-questdb-tcp-auth` assembly will be required.

When using the client to send ILP over HTTP, additional references and dependencies will not be required