### PR TITLE
Fix connecting via SenderOptions.addr

### DIFF
--- a/src/net-questdb-client-tests/MultiUrlHttpTests.cs
+++ b/src/net-questdb-client-tests/MultiUrlHttpTests.cs
@@ -45,22 +45,23 @@ public class MultiUrlHttpTests
     {
         // Test parsing multiple addresses from config string
         var options =
-            new SenderOptions("http::addr=localhost:9000;addr=localhost:9001;addr=localhost:9002;auto_flush=off;");
+            new SenderOptions("http::addr=localhost:9001;aDdR=locALhOSt:9002;addr=localhost:9003;auto_flush=off;");
 
+        Assert.That(options.addr, Is.EqualTo("localhost:9001"));
         Assert.That(options.AddressCount, Is.EqualTo(3));
-        Assert.That(options.addresses[0], Is.EqualTo("localhost:9000"));
-        Assert.That(options.addresses[1], Is.EqualTo("localhost:9001"));
-        Assert.That(options.addresses[2], Is.EqualTo("localhost:9002"));
+        Assert.That(options.addresses[0], Is.EqualTo("localhost:9001"));
+        Assert.That(options.addresses[1], Is.EqualTo("locALhOSt:9002"));
+        Assert.That(options.addresses[2], Is.EqualTo("localhost:9003"));
     }
 
     [Test]
     public void ParseMultipleAddresses_DefaultsToSingleAddress()
     {
         // Test that single address is handled correctly
-        var options = new SenderOptions("http::addr=localhost:9000;auto_flush=off;");
+        var options = new SenderOptions("http::addr=localhost:9999;auto_flush=off;");
 
         Assert.That(options.AddressCount, Is.EqualTo(1));
-        Assert.That(options.addresses[0], Is.EqualTo("localhost:9000"));
+        Assert.That(options.addresses[0], Is.EqualTo("localhost:9999"));
     }
 
     [Test]
@@ -69,7 +70,8 @@ public class MultiUrlHttpTests
         // Test that default address is used when none specified
         var options = new SenderOptions("http::auto_flush=off;");
 
-        Assert.That(options.AddressCount, Is.GreaterThan(0));
+        Assert.That(options.addr, Is.EqualTo("localhost:9000"));
+        Assert.That(options.AddressCount, Is.EqualTo(1));
         Assert.That(options.addresses[0], Is.EqualTo("localhost:9000"));
     }
 

--- a/src/net-questdb-client-tests/SenderOptionsTests.cs
+++ b/src/net-questdb-client-tests/SenderOptionsTests.cs
@@ -44,8 +44,8 @@ public class SenderOptionsTests
     public void BasicParse()
     {
         Assert.That(
-            new SenderOptions("http::addr=localhost:9000;").addr,
-            Is.EqualTo("localhost:9000"));
+            new SenderOptions("http::addr=localhost:9999;").addr,
+            Is.EqualTo("localhost:9999"));
     }
 
     [Test]
@@ -59,10 +59,37 @@ public class SenderOptionsTests
     [Test]
     public void DuplicateKey()
     {
-        // duplicate keys are 'last writer wins'
+        // duplicate (non-addr) keys are 'last writer wins'
         Assert.That(
-            new SenderOptions("http::addr=localhost:9000;addr=localhost:9009;").addr,
-            Is.EqualTo("localhost:9009"));
+            new SenderOptions("http::auth_timeout=15000;auth_timeout=8000;").auth_timeout,
+            Is.EqualTo(TimeSpan.FromMilliseconds(8000)));
+    }
+
+    [Test]
+    public void DefaultConstructorInit()
+    {
+        var options = new SenderOptions
+        {
+            addr = "192.168.0.218:9000",
+        };
+
+        Assert.That(options.addr, Is.EqualTo("192.168.0.218:9000"));
+        Assert.That(options.AddressCount, Is.EqualTo(1));
+        Assert.That(options.addresses[0], Is.EqualTo("192.168.0.218:9000"));
+    }
+
+    [Test]
+    public void SetGetAddr()
+    {
+        var options = new SenderOptions();
+
+        Assert.That(options.addr, Is.EqualTo("localhost:9000"));
+
+        options.addr = "192.168.0.218:9000";
+
+        Assert.That(options.addr, Is.EqualTo("192.168.0.218:9000"));
+        Assert.That(options.AddressCount, Is.EqualTo(1));
+        Assert.That(options.addresses[0], Is.EqualTo("192.168.0.218:9000"));
     }
 
     [Test]

--- a/src/net-questdb-client/Utils/SenderOptions.cs
+++ b/src/net-questdb-client/Utils/SenderOptions.cs
@@ -56,8 +56,8 @@ public record SenderOptions
         "pool_timeout", "tls_verify", "tls_roots", "tls_roots_password", "own_socket", "gzip",
     };
 
-    private string _addr = "localhost:9000";
-    private List<string> _addresses = new();
+    private const string DefaultAddress = "localhost:9000";
+    private readonly List<string> _addresses = new();
     private TimeSpan _authTimeout = TimeSpan.FromMilliseconds(15000);
     private AutoFlushType _autoFlush = AutoFlushType.on;
     private int _autoFlushBytes = int.MaxValue;
@@ -91,7 +91,7 @@ public record SenderOptions
     /// </summary>
     public SenderOptions()
     {
-        ParseAddresses();
+        addr = DefaultAddress;
     }
 
     /// <summary>
@@ -103,8 +103,6 @@ public record SenderOptions
         ReadConfigStringIntoBuilder(confStr);
         ParseEnumWithDefault(nameof(protocol), "http", out _protocol);
         ParseEnumWithDefault(nameof(protocol_version), "auto", out _protocol_version);
-        ParseStringWithDefault(nameof(addr), "localhost:9000", out _addr!);
-        ParseAddresses();
         ParseEnumWithDefault(nameof(auto_flush), "on", out _autoFlush);
         ParseIntThatMayBeOff(nameof(auto_flush_rows), IsHttp() ? "75000" : "600", out _autoFlushRows);
         ParseIntThatMayBeOff(nameof(auto_flush_bytes), int.MaxValue.ToString(), out _autoFlushBytes);
@@ -161,8 +159,12 @@ public record SenderOptions
     /// </remarks>
     public string addr
     {
-        get => _addr;
-        set => _addr = value;
+        get => _addresses[0];
+        set
+        {
+            _addresses.Clear();
+            _addresses.Add(value);
+        }
     }
 
     /// <summary>
@@ -595,19 +597,23 @@ public record SenderOptions
         // Parse addresses manually before using DbConnectionStringBuilder
         // because DbConnectionStringBuilder only keeps the last value for duplicate keys
         _addresses.Clear();
-        foreach (var param in paramString.Split(';'))
+        foreach (var param in paramString.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
         {
-            if (string.IsNullOrWhiteSpace(param)) continue;
-
-            var kvp = param.Split('=');
-            if (kvp.Length == 2 && kvp[0].Trim() == "addr")
+            if (!param.StartsWith("addr", StringComparison.OrdinalIgnoreCase))
             {
-                var addrValue = kvp[1].Trim();
-                if (!string.IsNullOrEmpty(addrValue))
-                {
-                    _addresses.Add(addrValue);
-                }
+                continue;
             }
+
+            var kvp = param.Split('=', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (kvp.Length == 2 && kvp[0].Equals("addr", StringComparison.OrdinalIgnoreCase))
+            {
+                _addresses.Add(kvp[1]);
+            }
+        }
+
+        if (_addresses.Count == 0)
+        {
+            _addresses.Add(DefaultAddress);
         }
 
         _connectionStringBuilder = new DbConnectionStringBuilder
@@ -701,15 +707,6 @@ public record SenderOptions
             {
                 throw new IngressError(ErrorCode.ConfigError, $"Invalid property: `{key}`");
             }
-        }
-    }
-
-    private void ParseAddresses()
-    {
-        // If no addresses were parsed from config string, use the primary addr
-        if (_addresses.Count == 0)
-        {
-            _addresses.Add(_addr);
         }
     }
 


### PR DESCRIPTION
After the multi-url change, when configuring the address to connect to by setting `SenderOptions.addr` rather than by passing a config string, the configured value is ignored.

Fix by making `addr` return the first value in `addresses` (as it is documented to do).

closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Enhanced address management with improved public API for accessing multiple addresses.
  - Added AddressCount property to query the number of configured addresses.

* **Bug Fixes**
  - Refined address parsing logic with better default address handling.
  - Improved case-insensitive recognition in configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->